### PR TITLE
fix(cron): Log output of nextcloud cron to syslog

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -45,5 +45,4 @@
   cron:
     name: "Nextcloud"
     minute: "*/15"
-    job: "php -f {{ nextcloud_path }}/cron.php"
-
+    job: "php -f {{ nextcloud_path }}/cron.php 2>&1 | /usr/bin/logger -t cron-nextcloud"


### PR DESCRIPTION
Otherwise it is impossible to get the log.
Cron tries to send a local mail for any log,
but we usally don't have local mail delivery configured.